### PR TITLE
Nexus 3.6.1-02

### DIFF
--- a/ci
+++ b/ci
@@ -149,7 +149,7 @@ docker container run -i ${TTY} ${REMOVE_ON_ERROR} --name "${CONTAINER_NAME}" -v 
 print_info "Cleaning up"
 docker_run "${CONTAINER_NAME}" "./clean"
 print_info "Installing required dependencies..."
-docker_run "${CONTAINER_NAME}" "/usr/bin/yum -q -y install rpm-build java-1.8.0-openjdk ${EXTRA_PACKAGES}"
+docker_run "${CONTAINER_NAME}" "/usr/bin/yum -q -y install rpm-build java-1.8.0 ${EXTRA_PACKAGES}"
 print_info "Configuring user ci..."
 docker_run "${CONTAINER_NAME}" "/usr/sbin/groupadd -g $(id -g) ci"
 docker_run "${CONTAINER_NAME}" "/usr/sbin/useradd -m -d /home/ci -u ${UID} -g $(id -g) ci"

--- a/nexus-oss-rpm
+++ b/nexus-oss-rpm
@@ -54,7 +54,7 @@ done
 shift $((OPTIND-1))
 
 case ${VERSION} in
-  3) VERSION="3.6.0-02"
+  3) VERSION="3.6.1-02"
      URL="http://download.sonatype.com/nexus/3/nexus-${VERSION}-unix.tar.gz"
      TGZ="nexus3-${VERSION}-unix.tar.gz"
      SPECS='nexus3-oss.spec';;


### PR DESCRIPTION
- Upgrade scripts to support Nexus 3.6.1-02
- Fix source
- Use package name to configure user to run Nexus
- Require Java 1.8.0