### PR TITLE
Added remove /etc/rc.d/init.d/%{name} and added systemd support

### DIFF
--- a/SOURCES/nexus3.service
+++ b/SOURCES/nexus3.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=Sonatype Nexus Repository Manager
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/etc/rc.d/init.d/nexus3 start
+ExecStop=/etc/rc.d/init.d/nexus3 stop
+User=nexus3
+Restart=on-abort
+#Environment=INSTALL4J_JAVA_HOME=/foo/bar/jre8
+LimitNOFILE=65536
+
+[Install]
+WantedBy=multi-user.target

--- a/SPECS/nexus3-oss.spec
+++ b/SPECS/nexus3-oss.spec
@@ -54,6 +54,9 @@ sed -i -e 's/<File>${karaf.data}\/log\/request.log<\/File>/<File>\/var\/log\/%{n
 %preun
 service %{name} stop
 
+%postun
+rm -f $RPM_BUILD_ROOT/etc/rc.d/init.d/%{name}
+
 %clean
 rm -rf $RPM_BUILD_ROOT
 

--- a/SPECS/nexus3-oss.spec
+++ b/SPECS/nexus3-oss.spec
@@ -13,6 +13,7 @@ Requires(postun): /usr/sbin/userdel
 AutoReqProv: no
 
 %define __os_install_post %{nil}
+%define use_systemd (0%{?fedora} && 0%{?fedora} >= 18) || (0%{?rhel} && 0%{?rhel} >= 7) || (0%{?suse_version} && 0%{?suse_version} >=1210)
 
 %description
 A package repository

--- a/SPECS/nexus3-oss.spec
+++ b/SPECS/nexus3-oss.spec
@@ -64,7 +64,6 @@ sed -i -e 's/<File>${karaf.data}\/log\/request.log<\/File>/<File>\/var\/log\/%{n
     /usr/bin/systemctl --no-reload disable %{name}.service >/dev/null 2>&1 || :
     /usr/bin/systemctl stop %{name}.service >/dev/null 2>&1 ||:
 %else
-service %{name} stop
     /sbin/service %{name} stop > /dev/null 2>&1
     /sbin/chkconfig --del %{name}
 %endif

--- a/SPECS/nexus3-oss.spec
+++ b/SPECS/nexus3-oss.spec
@@ -91,7 +91,9 @@ rm -rf $RPM_BUILD_ROOT
 %attr(-,%{name},%{name}) /var/lib/%{name}
 %attr(-,%{name},%{name}) /var/log/%{name}
 %attr(-,%{name},%{name}) /usr/share/%{name}
-
+%if %{use_systemd}
+%{_unitdir}/%{name}.service
+%endif
 %changelog
 
 * Sat Dec 2 2017 Julio Gonzalez <git@juliogonzalez.es> - 3.6.0-02


### PR DESCRIPTION
/etc/rc.d/init.d/nexus3 stay after remove package nexus3 

systemctl status nexus3.service 
Warning: nexus3.service changed on disk. Run 'systemctl daemon-reload' to reload units.
● nexus3.service - LSB: nexus
   Loaded: loaded (/etc/rc.d/init.d/nexus3; generated; vendor preset: disabled)
   Active: inactive (dead)
     Docs: man:systemd-sysv-generator(8)
