### PR TITLE
Nexus 2.14.11-01

### DIFF
--- a/SPECS/nexus-oss.spec
+++ b/SPECS/nexus-oss.spec
@@ -12,7 +12,7 @@
 Summary: Nexus manages software “artifacts” required for development, deployment, and provisioning.
 Name: nexus
 # Remember to adjust the version at Source0 as well. This is required for Open Build Service download_files service
-Version: 2.14.10.01
+Version: 2.14.11.01
 Release: 1%{?dist}
 # This is a hack, since Nexus versions are N.N.N-NN, we cannot use hyphen inside Version tag
 # and we need to adapt to Fedora/SUSE guidelines
@@ -20,7 +20,7 @@ Release: 1%{?dist}
 License: AGPL
 Group: unknown
 URL: http://nexus.sonatype.org/
-Source0: http://www.sonatype.org/downloads/%{name}-2.14.10-01-bundle.tar.gz
+Source0: http://www.sonatype.org/downloads/%{name}-2.14.11-01-bundle.tar.gz
 Source1: %{name}.service
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent
@@ -75,13 +75,14 @@ sed -i -e 's/wrapper.logfile=.*/wrapper.logfile=\/var\/log\/%{name}\/%{name}.log
 # Also it is possible that despite 1.8.0 is installed, it is not the default version, so we check
 # for it
 JAVA_MAJOR_VERSION=$(java -version 2>&1 | head -n 1 | cut -d'"' -f2 | cut -d'.' -f2)
-if [ "${JAVA_MAJOR_VERSION}" != "7" -a  "${JAVA_MAJOR_VERSION}" != "8" ]; then
-  echo "WARNING! Default java version does not seem to be neither 1.7 or 1.8!"
-  echo "Keep in mind that Nexus is only compatible with Java 1.7.0 and 1.8.0 at the moment!"
-  echo "Tip: Check if 1.7 or 1.8 is installed and use (as root):"
+if [ "${JAVA_MAJOR_VERSION}" != "8" ]; then
+  echo "WARNING! Default java version does not seem to be 1.8!"
+  echo "Keep in mind that Nexus3 is only compatible with Java 1.8.0 at the moment!"
+  echo "Tip: Check if 1.8 is installed and use (as root):"
   echo "update-alternatives --config java"
   echo "to adjust the default version to be used"
 fi
+
 
 %post
 %if %use_systemd
@@ -121,6 +122,10 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Fri Nov 23 2018 Julio Gonzalez <git@juliogonzalez.es> - 2.14.11.01-1
+- Update to 2.14.11-01
+- Require Java 1.8.0
+
 * Fri Nov 23 2018 Julio Gonzalez <git@juliogonzalez.es> - 2.14.10.01-1
 - Update to 2.14.10-01
 


### PR DESCRIPTION
This removes support for Java 7: https://help.sonatype.com/repomanager2/release-notes/2018-release-notes#id-2018ReleaseNotes-RepositoryManager2.14.11