### PR TITLE
Nexus 3.18.1-01

### DIFF
--- a/SPECS/nexus3-oss.spec
+++ b/SPECS/nexus3-oss.spec
@@ -12,7 +12,7 @@
 Summary: Nexus manages software “artifacts” required for development, deployment, and provisioning.
 Name: nexus3
 # Remember to adjust the version at Source0 as well. This is required for Open Build Service download_files service
-Version: 3.18.0.01
+Version: 3.18.1.01
 Release: 1%{?dist}
 # This is a hack, since Nexus versions are N.N.N-NN, we cannot use hyphen inside Version tag
 # and we need to adapt to Fedora/SUSE guidelines
@@ -20,7 +20,7 @@ Release: 1%{?dist}
 License: AGPL
 Group: unknown
 URL: http://nexus.sonatype.org/
-Source0: http://download.sonatype.com/nexus/3/nexus-3.18.0-01-unix.tar.gz
+Source0: http://download.sonatype.com/nexus/3/nexus-3.18.1-01-unix.tar.gz
 Source1: %{name}.service
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent
@@ -134,6 +134,12 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Tue Aug 20 2019 Julio Gonzalez Gil <packages@juliogonzalez.es> - 3.18.1.01-1
+- Update to Nexus 3.18.1-01
+- Bugfixes
+  * NEXUS-20674: Fixed an exception occurring when a user manually logs out of the user interface.
+  * NEXUS-19235: Propagates the quarantine status code when NXRM proxies another NXRM with Firewall enabled.
+
 * Mon Aug 19 2019 Julio Gonzalez Gil <packages@juliogonzalez.es> - 3.18.0.01-1
 - Update to Nexus 3.18.0-01
 - Bugfixes


### PR DESCRIPTION
- Update to Nexus 3.18.1-01
- Bugfixes
  * NEXUS-20674: Fixed an exception occurring when a user manually logs out of the user interface.
  * NEXUS-19235: Propagates the quarantine status code when NXRM proxies another NXRM with Firewall enabled.