### PR TITLE
Starting the containers with init is not needed anymore

### DIFF
--- a/docker/amazonlinux2/Dockerfile
+++ b/docker/amazonlinux2/Dockerfile
@@ -33,4 +33,4 @@ RUN groupadd -g ${GID} ci && \
 
 STOPSIGNAL SIGRTMIN+3
 
-CMD ["/sbin/init"]
+CMD ["/bin/bash", "/opt/start_wait.sh"]

--- a/docker/centos7/Dockerfile
+++ b/docker/centos7/Dockerfile
@@ -32,4 +32,4 @@ RUN groupadd -g ${GID} ci && \
 
 STOPSIGNAL SIGRTMIN+3
 
-CMD ["/sbin/init"]
+CMD ["/bin/bash", "/opt/start_wait.sh"]

--- a/docker/centos7/files/start_wait.sh
+++ b/docker/centos7/files/start_wait.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+while [ 0 = 0 ]; do
+  sleep 60
+done

--- a/docker/opensuse15.3/Dockerfile
+++ b/docker/opensuse15.3/Dockerfile
@@ -35,4 +35,4 @@ RUN groupadd -g ${GID} ci && \
 
 STOPSIGNAL SIGRTMIN+3
 
-CMD ["/sbin/init"]
+CMD ["/bin/bash", "/opt/start_wait.sh"]

--- a/docker/opensuse15.3/files/start_wait.sh
+++ b/docker/opensuse15.3/files/start_wait.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+while [ 0 = 0 ]; do
+  sleep 60
+done


### PR DESCRIPTION
Now that we use https://github.com/gdraheim/docker-systemctl-replacement, we don't need to start the containers with `/sbin/init` anymore (in fact starting with `/sbin/init` breaks stopping nexus2 on containers with systemd)