### PR TITLE
Nexus 3.70.3-01

### DIFF
--- a/SPECS/nexus3-oss.spec
+++ b/SPECS/nexus3-oss.spec
@@ -22,7 +22,7 @@
 Summary: Sonatype Nexus Repository manages software "artifacts" and repositories for them
 Name: nexus3
 # Remember to adjust the version at Source0 as well. This is required for Open Build Service download_files service
-Version: 3.70.2.01
+Version: 3.70.3.01
 Release: 1%{?dist}
 # This is a hack, since Nexus versions are N.N.N-NN, we cannot use hyphen inside Version tag
 # and we need to adapt to Fedora/SUSE guidelines
@@ -30,7 +30,7 @@ Release: 1%{?dist}
 License: EPL-2.0
 Group: Development/Tools/Other
 URL: http://nexus.sonatype.org/
-Source0: https://download.sonatype.com/nexus/3/nexus-3.70.2-01-java8-unix.tar.gz
+Source0: https://download.sonatype.com/nexus/3/nexus-3.70.3-01-java8-unix.tar.gz
 Source1: %{name}.service
 BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root
 Requires(pre): /usr/sbin/useradd, /usr/bin/getent
@@ -174,6 +174,17 @@ rm -rf $RPM_BUILD_ROOT
 %endif
 
 %changelog
+* Mon Oct 28 2024 Julio González Gil <packages@juliogonzalez.es> - 3.70.3.01-1
+- Update to 3.70.3-1
+- Dependency Updates in 3.70.3:
+  * Upgraded protobuf-java from 1.36.0 to 3.25.5
+  * Upgraded pax-url-aether from 2.6.7 to 2.6.12
+- WARNINGS:
+  * 3.70.3 is the final version supporting OrientDB, Java 8, and Java 11.
+    3.71.0+ will require either an H2 or PostgreSQL database and Java 17.
+    This means that this is the latest release that will build for CentOS7
+    or any other clones from third party providers.
+
 * Fri Sep  6 2024 Julio González Gil <packages@juliogonzalez.es> - 3.70.2.01-1
 - Update to 3.70.2-01
 - Fix for a Database Migrator issue that caused some users to see duplicate


### PR DESCRIPTION
I was going to bump to Java 17 on 3.70.2-01 before bumping, but it seems https://download.sonatype.com/nexus/3/nexus-3.70.2-01-java17-unix.tar.gz was not really for Java 17:

```
2024-10-27 23:18:22,096+0000 WARN  [jetty-main-1]  *SYSTEM org.eclipse.jetty.webapp.WebAppContext - Failed startup of context o.e.j.w.WebAppContext@77fcc322{Sonatype Nexus,/,null,UNAVAILABLE}
java.lang.IllegalStateException: The maximum Java version for OrientDb is Java 11. Please check current Java version meets this requirement.
        at org.sonatype.nexus.bootstrap.osgi.NexusEditionPropertiesConfigurer.ensureOrientRunningWithCorrectJavaRuntime(NexusEditionPropertiesConfigurer.java:154)
        at org.sonatype.nexus.bootstrap.osgi.NexusEditionPropertiesConfigurer.selectDbFeature(NexusEditionPropertiesConfigurer.java:143)
        at org.sonatype.nexus.bootstrap.osgi.NexusEditionPropertiesConfigurer.selectDatastoreFeature(NexusEditionPropertiesConfigurer.java:132)
        at org.sonatype.nexus.bootstrap.osgi.NexusEditionPropertiesConfigurer.getPropertiesFromConfiguration(NexusEditionPropertiesConfigurer.java:58)
        at org.sonatype.nexus.bootstrap.osgi.BootstrapListener.contextInitialized(BootstrapListener.java:58)
        at org.eclipse.jetty.server.handler.ContextHandler.callContextInitialized(ContextHandler.java:1073)
        at org.eclipse.jetty.servlet.ServletContextHandler.callContextInitialized(ServletContextHandler.java:572)
        at org.eclipse.jetty.server.handler.ContextHandler.contextInitialized(ContextHandler.java:1002)
        at org.eclipse.jetty.servlet.ServletHandler.initialize(ServletHandler.java:765)
        at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:379)
        at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1449)
        at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1414)
        at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:916)
        at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:288)
        at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:524)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:110)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97)
        at com.codahale.metrics.jetty9.InstrumentedHandler.doStart(InstrumentedHandler.java:101)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:117)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169)
        at org.eclipse.jetty.server.Server.start(Server.java:423)
        at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:110)
        at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97)
        at org.eclipse.jetty.server.Server.doStart(Server.java:387)
        at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
        at org.sonatype.nexus.bootstrap.jetty.JettyServer$JettyMainThread.run(JettyServer.java:274)
```
Which makes sense, as the Java17 variant was not published for neither 3.70.2 or 3.70.3 at the site.